### PR TITLE
Add support for sticky comments

### DIFF
--- a/api/modposts.js
+++ b/api/modposts.js
@@ -12,14 +12,15 @@ reddit._addSimpleRequest("spam", "remove", "POST", ["id"], {"spam": true}, "_noR
 reddit._addSimpleRequest("contestMode", "set_contest_mode", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 reddit._addSimpleRequest("sticky", "set_subreddit_sticky", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 
-reddit.prototype.distinguish = function(thing, distinguish, sticky, callback) {
+reddit.prototype.distinguish = function(thing, distinguish, callback, sticky) {
 	if(distinguish === true) {
 		distinguish = 'yes';
 	} else if(distinguish === false) {
 		distinguish = 'no';
 	}
 	
-	var self = this;
+	var self   = this,
+	    sticky = typeof sticky !== 'undefined' ?  sticky : false;
 	this._apiRequest("distinguish", {"method": "POST", "form": {
 		"api_type": "json",
 		"how": distinguish,

--- a/api/modposts.js
+++ b/api/modposts.js
@@ -12,15 +12,19 @@ reddit._addSimpleRequest("spam", "remove", "POST", ["id"], {"spam": true}, "_noR
 reddit._addSimpleRequest("contestMode", "set_contest_mode", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 reddit._addSimpleRequest("sticky", "set_subreddit_sticky", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 
-reddit.prototype.distinguish = function(thing, distinguish, callback, sticky) {
+reddit.prototype.distinguish = function(thing, distinguish, callback) {
 	if(distinguish === true) {
 		distinguish = 'yes';
+		sticky = false;
 	} else if(distinguish === false) {
 		distinguish = 'no';
+		sticky = false;
+	} else if(distinguish === 'sticky') {
+		distinguish = 'yes';
+		sticky = true;
 	}
 	
-	var self   = this,
-	    sticky = typeof sticky !== 'undefined' ?  sticky : false;
+	var self   = this;
 	this._apiRequest("distinguish", {"method": "POST", "form": {
 		"api_type": "json",
 		"how": distinguish,

--- a/api/modposts.js
+++ b/api/modposts.js
@@ -13,6 +13,9 @@ reddit._addSimpleRequest("contestMode", "set_contest_mode", "POST", ["id", "stat
 reddit._addSimpleRequest("sticky", "set_subreddit_sticky", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 
 reddit.prototype.distinguish = function(thing, distinguish, callback) {
+	var self = this,
+	    sticky = false;
+
 	if(distinguish === true) {
 		distinguish = 'yes';
 		sticky = false;
@@ -23,8 +26,7 @@ reddit.prototype.distinguish = function(thing, distinguish, callback) {
 		distinguish = 'yes';
 		sticky = true;
 	}
-	
-	var self   = this;
+
 	this._apiRequest("distinguish", {"method": "POST", "form": {
 		"api_type": "json",
 		"how": distinguish,

--- a/api/modposts.js
+++ b/api/modposts.js
@@ -12,7 +12,7 @@ reddit._addSimpleRequest("spam", "remove", "POST", ["id"], {"spam": true}, "_noR
 reddit._addSimpleRequest("contestMode", "set_contest_mode", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 reddit._addSimpleRequest("sticky", "set_subreddit_sticky", "POST", ["id", "state"], {"api_type": "json"}, "_noResponse");
 
-reddit.prototype.distinguish = function(thing, distinguish, callback) {
+reddit.prototype.distinguish = function(thing, distinguish, sticky, callback) {
 	if(distinguish === true) {
 		distinguish = 'yes';
 	} else if(distinguish === false) {
@@ -23,7 +23,8 @@ reddit.prototype.distinguish = function(thing, distinguish, callback) {
 	this._apiRequest("distinguish", {"method": "POST", "form": {
 		"api_type": "json",
 		"how": distinguish,
-		"id": thing
+		"id": thing,
+		"sticky": sticky
 	}}, function(err, response, body) {
 		self._modifySingleItem(err, body, callback);
 	});


### PR DESCRIPTION
This sends a boolean param named "sticky" along with a distinguish request. This will sticky the distinguished mod comment. I've tested this in a bot I'm running and seems to work fine.
